### PR TITLE
Fix keyword highlighting of setAlarmTemperature

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ begin		          	KEYWORD2
 thermometers			  KEYWORD2
 readTemp		      	KEYWORD2
 setPrecision			  KEYWORD2
-setAlarmTemperature KEYWORD2
+setAlarmTemperature	KEYWORD2
 getAlarm			      KEYWORD2
 setPolarity			    KEYWORD2
 setContinuous			  KEYWORD2


### PR DESCRIPTION
In order for Arduino IDE's keyword highlighting system to work the keyword must be separated from the identifier by a tab, which was previously not done for `setAlarmTemperature`.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords